### PR TITLE
fix(hmr): some files do not have a url

### DIFF
--- a/lib/hmr.js
+++ b/lib/hmr.js
@@ -317,12 +317,14 @@ module.exports = (options = {}) => {
     // 2. delete foo.js
     // 3. change: foo.js <- (!) will think foo is not accepted
     //
-    const forget = Object.keys(changed).map(file => {
-      const url = fileUrls[file]
-      delete fileUrls[file]
-      delete changed[file]
-      return url
-    })
+    const forget = Object.keys(changed)
+      .map(file => {
+        const url = fileUrls[file]
+        delete fileUrls[file]
+        delete changed[file]
+        return url
+      })
+      .filter(Boolean)
 
     // NOTE we must broadcast empty changesets, or the client will get stuck in
     // 'prepare' state


### PR DESCRIPTION
Adding these as `undefined` or `null` to the `forget` array leads to an unrecoverable error in the client hmr code. This changes ensures that each entry in the `forget` array is a url.